### PR TITLE
BeatMods update

### DIFF
--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -35,7 +35,7 @@ namespace BeatSaberModManager.Core
                 StatusUpdate("Starting install sequence...");
 
                 ReleaseInfo bsipa = null;
-                if ((bsipa = releases.Find(release => release.name == "bsipa")) != null)
+                if ((bsipa = releases.Find(release => release.name.ToLower() == "bsipa")) != null)
                 {
                     StatusUpdate($"Downloading...{bsipa.title}");
                     byte[] file = Helper.GetFile(bsipa.downloadLink);

--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -43,7 +43,7 @@ namespace BeatSaberModManager.Core
                         StatusUpdate(string.Format("Unzipped! {0}", release.title));
                     }
                 }
-                Process.Start(installDirectory + @"\IPA.exe");
+                Process.Start(installDirectory + @"\IPA.exe", Quoted(installDirectory + @"\Beat Saber.exe"));
                 StatusUpdate("Install complete!");
             } catch (Exception ex)
             {

--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -43,11 +43,12 @@ namespace BeatSaberModManager.Core
                         StatusUpdate(string.Format("Unzipped! {0}", release.title));
                     }
                 }
-                Process.Start(installDirectory + @"\IPA.exe", Quoted(installDirectory + @"\Beat Saber.exe"));
+                Process.Start(installDirectory + @"\IPA.exe");
                 StatusUpdate("Install complete!");
             } catch (Exception ex)
             {
                 StatusUpdate("Install failed! " + ex.ToString());
+                Console.WriteLine("Install failed! " + ex.ToString());
             }
             
         }

--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace BeatSaberModManager.Core
 {
@@ -32,18 +33,49 @@ namespace BeatSaberModManager.Core
             try
             {
                 StatusUpdate("Starting install sequence...");
+
+                ReleaseInfo bsipa = null;
+                if ((bsipa = releases.Find(release => release.name == "bsipa")) != null)
+                {
+                    StatusUpdate($"Downloading...{bsipa.title}");
+                    byte[] file = Helper.GetFile(bsipa.downloadLink);
+                    StatusUpdate($"Unzipping...{bsipa.title}");
+                    Helper.UnzipFile(file, installDirectory);
+                    StatusUpdate($"Unzipped! {bsipa.title}");
+
+                    releases.Remove(bsipa); // don't want to double down
+                }
+
+                var toInstall = bsipa == null ? installDirectory : Path.Combine(installDirectory, "IPA", "Pending");
+                Directory.CreateDirectory(toInstall);
+
                 foreach (ReleaseInfo release in releases)
                 {
                     if (release.install)
                     {
-                        StatusUpdate(string.Format("Downloading...{0}", release.title));
+                        StatusUpdate($"Downloading...{release.title}");
                         byte[] file = Helper.GetFile(release.downloadLink);
-                        StatusUpdate(string.Format("Unzipping...{0}", release.title));
-                        Helper.UnzipFile(file, installDirectory);
-                        StatusUpdate(string.Format("Unzipped! {0}", release.title));
+                        StatusUpdate($"Unzipping...{release.title}");
+                        Helper.UnzipFile(file, toInstall);
+                        StatusUpdate($"Unzipped! {release.title}");
                     }
                 }
-                Process.Start(installDirectory + @"\IPA.exe", Quoted(installDirectory + @"\Beat Saber.exe"));
+
+                if (bsipa != null)
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(installDirectory, "IPA.exe"),
+                        WorkingDirectory = installDirectory,
+                        Arguments = "-fn"
+                    }).WaitForExit();
+                else
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = Path.Combine(installDirectory, "IPA.exe"),
+                        WorkingDirectory = installDirectory,
+                        Arguments = Quoted(Path.Combine(installDirectory, "Beat Saber.exe"))
+                    }).WaitForExit();
+                
                 StatusUpdate("Install complete!");
             } catch (Exception ex)
             {

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -68,7 +68,7 @@ namespace BeatSaberModManager.Core
                 {
                     var current = mods[i];
 
-                    List<ModLink> dependsOn = new List<ModLink>(); //NodeToLinks(current["dependencies"]);
+                    List<ModLink> dependsOn = NodeToLinks(current["dependencies"]);
                     List<ModLink> conflictsWith = new List<ModLink>(); //NodeToLinks(current["links"]["conflicts"]);
 
                     var files = current["downloads"];
@@ -123,8 +123,8 @@ namespace BeatSaberModManager.Core
 
             foreach (string str in arr)
             {
-                string[] split = str.Split('@');
-                ModLink link = new ModLink(split[0], split[1]);
+                var parsed = JSON.Parse(str);
+                ModLink link = new ModLink(parsed["name"], parsed["version"]);
                 links.Add(link);
             }
 

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -72,6 +72,12 @@ namespace BeatSaberModManager.Core
                     List<ModLink> conflictsWith = new List<ModLink>(); //NodeToLinks(current["links"]["conflicts"]);
 
                     var files = current["downloads"];
+
+                    for(var f = 0; f < files.Count; ++f)
+                    {
+                        files[f]["url"] = BeatModsURL + files[f]["url"];
+                    }
+
                     if (files.Count > 1)
                     {
                         var steam = files[0];

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -68,31 +68,31 @@ namespace BeatSaberModManager.Core
                 {
                     var current = mods[i];
 
-                    List<ModLink> dependsOn = NodeToLinks(current["links"]["dependencies"]);
-                    List<ModLink> conflictsWith = NodeToLinks(current["links"]["conflicts"]);
+                    List<ModLink> dependsOn = new List<ModLink>(); //NodeToLinks(current["dependencies"]);
+                    List<ModLink> conflictsWith = new List<ModLink>(); //NodeToLinks(current["links"]["conflicts"]);
 
-                    var files = current["files"];
+                    var files = current["downloads"];
                     if (files.Count > 1)
                     {
                         var steam = files[0];
                         var oculus = files[1];
 
                         CreateRelease(
-                            new ReleaseInfo(current["name"], current["details"]["title"], current["version"], current["details"]["author"]["name"],
-                            current["details"]["description"], current["meta"]["weight"], current["gameVersion"]["value"],
-                            steam["url"], current["meta"]["category"], Platform.Steam, dependsOn, conflictsWith));
+                            new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
+                            current["description"], 0, "0.13.2", steam["url"],
+                            current["category"], Platform.Default, dependsOn, conflictsWith));
 
                         CreateRelease(
-                            new ReleaseInfo(current["name"], current["details"]["title"], current["version"], current["details"]["author"]["name"],
-                            current["details"]["description"], current["meta"]["weight"], current["gameVersion"]["value"],
-                            oculus["url"], current["meta"]["category"], Platform.Oculus, dependsOn, conflictsWith));
+                            new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
+                            current["description"], 0, "0.13.2", oculus["url"],
+                            current["category"], Platform.Default, dependsOn, conflictsWith));
                     }
                     else
                     {
                         CreateRelease(
-                            new ReleaseInfo(current["name"], current["details"]["title"], current["version"], current["details"]["author"]["name"],
-                            current["details"]["description"], current["meta"]["weight"], current["gameVersion"]["value"],
-                            files["steam"]["url"], current["meta"]["category"], Platform.Default, dependsOn, conflictsWith));
+                            new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
+                            current["description"], 0, "0.13.2", files[0]["url"],
+                            current["category"], Platform.Default, dependsOn, conflictsWith));
                     }
                 }
             }

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -14,13 +14,13 @@ namespace BeatSaberModManager.Core
     public class RemoteLogic
     {
 #if DEBUG
-        private const string ModSaberURL = "https://staging.modsaber.org";
+        private const string BeatModsURL = "https://beatmods.com";
 #else
-        private const string ModSaberURL = "https://www.modsaber.org";
+        private const string BeatModsURL = "https://beatmods.com";
 #endif
 
-        private const string ApiVersion = "1.1";
-        private readonly string ApiURL = $"{ModSaberURL}/api/v{ApiVersion}";
+        private const string ApiVersion = "1";
+        private readonly string ApiURL = $"{BeatModsURL}/api/v{ApiVersion}";
 
         public GameVersion[] gameVersions;
         public GameVersion selectedGameVersion;
@@ -60,7 +60,7 @@ namespace BeatSaberModManager.Core
         {
             releases.Clear();
 
-            string raw = GetModSaberReleases();
+            string raw = GetBeatModsReleases();
             if (raw != null)
             {
                 var mods = JSON.Parse(raw);
@@ -127,7 +127,7 @@ namespace BeatSaberModManager.Core
 
         private string Fetch(string URL) => Helper.Get(URL);
 
-        private string GetModSaberReleases()
+        private string GetBeatModsReleases()
         {
             string raw = Fetch($"{ApiURL}/mods/approved/all");
             var decoded = JSON.Parse(raw);

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -129,28 +129,15 @@ namespace BeatSaberModManager.Core
 
         private string GetBeatModsReleases()
         {
-            string raw = Fetch($"{ApiURL}/mods/approved/all");
+            string raw = Fetch($"{ApiURL}/mod?status=approved");
             var decoded = JSON.Parse(raw);
-            int lastPage = decoded["lastPage"];
-
-            JSONArray final = new JSONArray();
-
-            for (int i = 0; i <= lastPage; i++)
-            {
-                string page = Fetch($"{ApiURL}/mods/approved/all/{i}");
-                var pageDecoded = JSON.Parse(page);
-                var mods = pageDecoded["mods"];
-
-                foreach (var x in mods)
-                    final.Add(x.Value);
-            }
-            return final.ToString();
+            return decoded.ToString();
         }
 
         private void CreateRelease(ReleaseInfo release)
         {
-            if (release.gameVersion != selectedGameVersion.value)
-                return;
+            //if (release.gameVersion != selectedGameVersion.value)
+            //    return;
 
             ReleaseInfo current = releases.Find(x => x.name == release.name);
             if (current == null)

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -69,7 +69,7 @@ namespace BeatSaberModManager.Core
                     var current = mods[i];
 
                     List<ModLink> dependsOn = NodeToLinks(current["dependencies"]);
-                    List<ModLink> conflictsWith = new List<ModLink>(); //NodeToLinks(current["links"]["conflicts"]);
+                    List<ModLink> conflictsWith = NodeToLinks(current["conflicts"]);
 
                     var files = current["downloads"];
 

--- a/BeatSaberModManager/Core/UpdateLogic.cs
+++ b/BeatSaberModManager/Core/UpdateLogic.cs
@@ -14,7 +14,7 @@ namespace BeatSaberModManager.Core
 {
     class UpdateLogic
     {
-        static readonly string repo = "Umbranoxio/BeatSaberModInstaller";
+        static readonly string repo = "beat-saber-modding-group/BeatSaberModInstaller";
         static readonly string releaseURL = $"https://api.github.com/repos/{repo}/releases/latest";
 
         public JSONNode LatestRelease()

--- a/BeatSaberModManager/DataModels/ReleaseInfo.cs
+++ b/BeatSaberModManager/DataModels/ReleaseInfo.cs
@@ -46,7 +46,7 @@ namespace BeatSaberModManager.DataModels
             weight = _weight;
             gameVersion = _gameVersion;
             downloadLink = _downloadLink;
-            category = _category;
+            category = _category.First().ToString().ToUpper() + _category.Substring(1);
             platform = _platform;
             dependsOn = _dependsOn;
             conflictsWith = _conflictsWith;

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -62,7 +62,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
             this.helpInfoLabel3 = new System.Windows.Forms.Label();
-            this.comboBox_gameVersions = new System.Windows.Forms.ComboBox();
+            this.label5 = new System.Windows.Forms.Label();
             this.tabControlMain.SuspendLayout();
             this.tabPageCore.SuspendLayout();
             this.contextMenuStripMain.SuspendLayout();
@@ -234,10 +234,10 @@
             this.linkLabellolPants.AutoSize = true;
             this.linkLabellolPants.Location = new System.Drawing.Point(386, 92);
             this.linkLabellolPants.Name = "linkLabellolPants";
-            this.linkLabellolPants.Size = new System.Drawing.Size(48, 13);
+            this.linkLabellolPants.Size = new System.Drawing.Size(57, 13);
             this.linkLabellolPants.TabIndex = 5;
             this.linkLabellolPants.TabStop = true;
-            this.linkLabellolPants.Text = "lolPants";
+            this.linkLabellolPants.Text = "vanZeben";
             this.linkLabellolPants.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabellolPants_LinkClicked);
             // 
             // linkLabelUmbranox
@@ -278,10 +278,10 @@
             this.linkLabelModSaberLink.AutoSize = true;
             this.linkLabelModSaberLink.Location = new System.Drawing.Point(273, 92);
             this.linkLabelModSaberLink.Name = "linkLabelModSaberLink";
-            this.linkLabelModSaberLink.Size = new System.Drawing.Size(60, 13);
+            this.linkLabelModSaberLink.Size = new System.Drawing.Size(59, 13);
             this.linkLabelModSaberLink.TabIndex = 1;
             this.linkLabelModSaberLink.TabStop = true;
-            this.linkLabelModSaberLink.Text = "ModSaber";
+            this.linkLabelModSaberLink.Text = "BeatMods";
             this.linkLabelModSaberLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelModSaberLink_LinkClicked);
             // 
             // labelModSaber1
@@ -432,25 +432,23 @@
             this.helpInfoLabel3.TabIndex = 3;
             this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
-            // comboBox_gameVersions
+            // label5
             // 
-            this.comboBox_gameVersions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.comboBox_gameVersions.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBox_gameVersions.DropDownWidth = 70;
-            this.comboBox_gameVersions.Enabled = false;
-            this.comboBox_gameVersions.FormattingEnabled = true;
-            this.comboBox_gameVersions.Location = new System.Drawing.Point(502, 26);
-            this.comboBox_gameVersions.Name = "comboBox_gameVersions";
-            this.comboBox_gameVersions.Size = new System.Drawing.Size(72, 21);
-            this.comboBox_gameVersions.TabIndex = 11;
-            this.comboBox_gameVersions.SelectedIndexChanged += new System.EventHandler(this.comboBox_gameVersions_SelectedIndexChanged);
+            this.label5.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(507, 30);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(67, 13);
+            this.label5.TabIndex = 11;
+            this.label5.Text = "v0.13.2 only";
+            this.label5.Click += new System.EventHandler(this.label5_Click);
             // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(588, 436);
-            this.Controls.Add(this.comboBox_gameVersions);
+            this.Controls.Add(this.label5);
             this.Controls.Add(this.panelInfo);
             this.Controls.Add(this.buttonViewInfo);
             this.Controls.Add(this.tabControlMain);
@@ -463,7 +461,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FormMain";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Beat Saber Mod Manager (Beat Mods Edition!)";
+            this.Text = "Beat Saber Mod Manager (Beat Mods Edition!) BETA!";
             this.Load += new System.EventHandler(this.FormMain_Load);
             this.tabControlMain.ResumeLayout(false);
             this.tabPageCore.ResumeLayout(false);
@@ -514,7 +512,7 @@
         private System.Windows.Forms.Label labelDiscordInfo;
         private System.Windows.Forms.LinkLabel linkLabelDiscord;
         private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.ComboBox comboBox_gameVersions;
+        private System.Windows.Forms.Label label5;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -434,7 +434,7 @@
             // 
             // label5
             // 
-            this.label5.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(507, 30);
             this.label5.Name = "label5";

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -463,7 +463,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "FormMain";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Beat Saber Mod Manager";
+            this.Text = "Beat Saber Mod Manager (Beat Mods Edition!)";
             this.Load += new System.EventHandler(this.FormMain_Load);
             this.tabControlMain.ResumeLayout(false);
             this.tabPageCore.ResumeLayout(false);

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -170,7 +170,8 @@ namespace BeatSaberModManager
         private void CheckDefaultMod(ReleaseInfo release, ListViewItem item)
         {
             string link = release.downloadLink.ToLower();
-            if (link.Contains("bsipa"))
+            string category = release.category.ToLower();
+            if (link.Contains("bsipa") || category.Contains("libraries"))
             {
                 item.Text = $"[REQUIRED] {release.title}";
                 item.BackColor = Color.LightGray;

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -38,7 +38,7 @@ namespace BeatSaberModManager
         {
             try
             {
-                updater.CheckForUpdates();
+                //updater.CheckForUpdates();
                 textBoxDirectory.Text = path.GetInstallationPath();
              
                 new Thread(() => { RemoteLoad(); }).Start();
@@ -52,6 +52,7 @@ namespace BeatSaberModManager
 
         private void RemoteLoad()
         {
+            /*
             UpdateStatus("Loading game versions...");
             remote.GetGameVersions();
             for (int i = 0; i < remote.gameVersions.Length; i++)
@@ -60,6 +61,7 @@ namespace BeatSaberModManager
                 this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); })); 
             }
             this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
+            */
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
             installer = new InstallerLogic(remote.releases, path.installPath);

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -38,7 +38,7 @@ namespace BeatSaberModManager
         {
             try
             {
-                //updater.CheckForUpdates();
+                updater.CheckForUpdates();
                 textBoxDirectory.Text = path.GetInstallationPath();
              
                 new Thread(() => { RemoteLoad(); }).Start();
@@ -62,6 +62,8 @@ namespace BeatSaberModManager
             }
             this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
             */
+            //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add("0.13.2"); }));
+            //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
             installer = new InstallerLogic(remote.releases, path.installPath);
@@ -76,7 +78,7 @@ namespace BeatSaberModManager
             // God knows why
             // listViewMods.Items.Clear();
             UpdateStatus("Loading releases...");
-            comboBox_gameVersions.Enabled = false;
+            //comboBox_gameVersions.Enabled = false;
             if (!first)
             {
                 ComboBox comboBox = (ComboBox)sender;
@@ -98,7 +100,7 @@ namespace BeatSaberModManager
 
         private void ShowReleases()
         {
-            comboBox_gameVersions.Enabled = true;
+            //comboBox_gameVersions.Enabled = true;
             Dictionary<string, int> groups = new Dictionary<string, int>();
 
             listViewMods.Groups.Clear();
@@ -334,12 +336,12 @@ namespace BeatSaberModManager
 
         private void linkLabellolPants_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/lolPants");
+            Process.Start("https://github.com/vanZeben");
         }
 
         private void linkLabelModSaberLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://www.modsaber.org/faq");
+            Process.Start("https://beatmods.com/");
         }
 
         private void linkLabelUmbranox_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -349,7 +351,7 @@ namespace BeatSaberModManager
 
         private void linkLabelContributors_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/Umbranoxio/BeatSaberModInstaller/graphs/contributors");
+            Process.Start("https://github.com/beat-saber-modding-group/BeatSaberModInstaller/graphs/contributors");
         }
 
         private void textBoxDirectory_TextChanged(object sender, EventArgs e)
@@ -379,5 +381,10 @@ namespace BeatSaberModManager
             Process.Start("https://discord.gg/beatsabermods");
         }
         #endregion
+
+        private void label5_Click(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -170,7 +170,7 @@ namespace BeatSaberModManager
         private void CheckDefaultMod(ReleaseInfo release, ListViewItem item)
         {
             string link = release.downloadLink.ToLower();
-            if (link.Contains("songloader"))
+            if (link.Contains("bsipa"))
             {
                 item.Text = $"[REQUIRED] {release.title}";
                 item.BackColor = Color.LightGray;
@@ -180,7 +180,7 @@ namespace BeatSaberModManager
                 item.Checked = true;
             }
 
-            if (link.Contains("scoresaber") || link.Contains("beatsaverdownloader"))
+            if (link.Contains("songloader") || link.Contains("scoresaber") || link.Contains("beatsaverdownloader"))
             {
                 item.Checked = true;
                 release.install = true;

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -170,7 +170,7 @@ namespace BeatSaberModManager
         private void CheckDefaultMod(ReleaseInfo release, ListViewItem item)
         {
             string link = release.downloadLink.ToLower();
-            if (link.Contains("song-loader"))
+            if (link.Contains("songloader"))
             {
                 item.Text = $"[REQUIRED] {release.title}";
                 item.BackColor = Color.LightGray;
@@ -180,7 +180,7 @@ namespace BeatSaberModManager
                 item.Checked = true;
             }
 
-            if (link.Contains("song-loader") || link.Contains("scoresaber") || link.Contains("beatsaver"))
+            if (link.Contains("scoresaber") || link.Contains("beatsaverdownloader"))
             {
                 item.Checked = true;
                 release.install = true;

--- a/BeatSaberModManager/Properties/AssemblyInfo.cs
+++ b/BeatSaberModManager/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2.2")]
+[assembly: AssemblyVersion("0.3.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: NeutralResourcesLanguage("en")]
 

--- a/BeatSaberModManager/Properties/AssemblyInfo.cs
+++ b/BeatSaberModManager/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0.2")]
+[assembly: AssemblyVersion("0.3.0.3")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: NeutralResourcesLanguage("en")]
 

--- a/BeatSaberModManager/Properties/AssemblyInfo.cs
+++ b/BeatSaberModManager/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Beat Saber Mod Manager")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Beat Saber Mod Manager Beat Mods BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BeatSaberModManager")]
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyVersion("0.3.0.2")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: NeutralResourcesLanguage("en")]
 


### PR DESCRIPTION
**Update**
- Updated to work with https://beatmods.com api
- Updated to work with BSIPA
- Doesn't lock dependencies correctly, so it simply forces all libraries to "Required" for now
- Removed combobox select, since BeatMods doesn't support game version yet
- Update check now points to https://api.github.com/repos/beat-saber-modding-group/BeatSaberModInstaller/releases/latest