### PR TITLE
Added BeatSaver OneClick installer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.cs]
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/BeatSaberModManager/BeatSaberModManager.csproj
+++ b/BeatSaberModManager/BeatSaberModManager.csproj
@@ -51,6 +51,9 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="MaterialSkin, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MaterialSkin.0.2.1\lib\MaterialSkin.dll</HintPath>
@@ -73,6 +76,7 @@
     <Compile Include="Core\GroupSorter.cs" />
     <Compile Include="Core\Helper.cs" />
     <Compile Include="Core\InstallerLogic.cs" />
+    <Compile Include="Core\OneClickInstaller.cs" />
     <Compile Include="Core\PathLogic.cs" />
     <Compile Include="Core\RemoteLogic.cs" />
     <Compile Include="Core\UpdateLogic.cs" />
@@ -227,6 +231,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\FormMain.resx">
       <DependentUpon>FormMain.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\FormPlatformSelect.resx">
       <DependentUpon>FormPlatformSelect.cs</DependentUpon>

--- a/BeatSaberModManager/Core/OneClickInstaller.cs
+++ b/BeatSaberModManager/Core/OneClickInstaller.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace BeatSaberModManager.Core
+{
+    /// <summary>
+    /// Provides methods related to the OneClick installer for https://beatsaver.com/.
+    /// </summary>
+    static class OneClickInstaller
+    {
+        private const string OneClickProviderKey = "OneClick-Provider";
+        private const string OneClickInstallerName = "BSMG-BeatSaberModInstaller";
+        private static readonly Regex BeatSaverId = new Regex(@"(modsaber://song/)?(\d+-\d+)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.ECMAScript);
+        private static PathLogic _pathLogic;
+        private static PathLogic PathLogic => _pathLogic = _pathLogic ?? new PathLogic();
+
+        private const int HWND_BROADCAST = 0xffff;
+        public static readonly int WM_DL_START = RegisterWindowMessage("WM_DL_START");
+        public static readonly int WM_DL_SUCCESS = RegisterWindowMessage("WM_DL_SUCCESS");
+        public static readonly int WM_DL_FAIL = RegisterWindowMessage("WM_DL_FAIL");
+
+        // Some native util methods to notify the main window about a song download status.
+        [DllImport("user32")]
+        private static extern bool PostMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
+        [DllImport("user32")]
+        private static extern int RegisterWindowMessage(string message);
+
+        /// <summary>Checks whether the OneClick installer is registered.</summary>
+        /// <returns>True when registered, false otherwise.</returns>
+        public static bool CheckRegistered()
+        {
+            using (var modsaberKey = Registry.ClassesRoot.OpenSubKey("modsaber"))
+            {
+                if (modsaberKey == null)
+                    return false;
+                return modsaberKey.GetValue(OneClickProviderKey) is string provider
+                    && provider == OneClickInstallerName;
+            }
+        }
+
+        public static void Register()
+        {
+            using (var modsaberKey = Registry.ClassesRoot.CreateSubKey("modsaber"))
+            using (var commandKey = modsaberKey.CreateSubKey(@"shell\open\command"))
+            {
+                modsaberKey.SetValue("URL Protocol", "", RegistryValueKind.String);
+                modsaberKey.SetValue(OneClickProviderKey, OneClickInstallerName, RegistryValueKind.String);
+                var exeLocation = Assembly.GetEntryAssembly().Location;
+                commandKey.SetValue("", $"\"{exeLocation}\" \"--install-song\" \"%1\"");
+            }
+        }
+
+        public static void Unregister()
+        {
+            Registry.ClassesRoot.DeleteSubKeyTree("modsaber");
+        }
+
+        public static void InstallSong(string idString)
+        {
+            BroadcastDownloadStatus(DownloadStatus.Started);
+
+            // Check if we got a valid beatsaver id and extract it
+            var match = BeatSaverId.Match(idString);
+            if (!match.Success)
+            {
+                BroadcastDownloadStatus(DownloadStatus.Failed);
+                return;
+            }
+            var id = match.Groups[2].Value;
+
+            // Get the custom songs folder
+            var bsPath = PathLogic.GetInstallationPath();
+            if (string.IsNullOrEmpty(bsPath))
+            {
+                BroadcastDownloadStatus(DownloadStatus.Failed);
+                return;
+            }
+
+            try
+            {
+                // Create an id folder for the song
+                var songPath = Path.Combine(bsPath, "CustomSongs", id);
+                Directory.CreateDirectory(songPath);
+
+                // Donwload and extract
+                var data = Helper.GetFile($"https://beatsaver.com/download/{id}");
+                Helper.UnzipFile(data, songPath);
+            }
+            catch
+            {
+                BroadcastDownloadStatus(DownloadStatus.Failed);
+                return;
+            }
+
+            BroadcastDownloadStatus(DownloadStatus.Succeeded);
+        }
+
+        private static void BroadcastDownloadStatus(DownloadStatus status)
+        {
+            int message;
+            switch (status)
+            {
+            case DownloadStatus.Started: message = WM_DL_START; break;
+            case DownloadStatus.Succeeded: message = WM_DL_SUCCESS; break;
+            case DownloadStatus.Failed: message = WM_DL_FAIL; break;
+            default: return;
+            }
+            PostMessage((IntPtr)HWND_BROADCAST, message, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private enum DownloadStatus
+        {
+            Started,
+            Succeeded,
+            Failed,
+        }
+    }
+}

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -39,6 +39,9 @@
             this.viewInfoToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.directDownloadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabPageCredits = new System.Windows.Forms.TabPage();
+            this.donateModdersBox = new System.Windows.Forms.PictureBox();
+            this.donateModdersLabel = new MaterialSkin.Controls.MaterialLabel();
+            this.pateronLabel = new MaterialSkin.Controls.MaterialLabel();
             this.patreonBox = new System.Windows.Forms.PictureBox();
             this.creditMaterialSkin = new MaterialSkin.Controls.MaterialRaisedButton();
             this.creditContributors = new MaterialSkin.Controls.MaterialRaisedButton();
@@ -60,6 +63,8 @@
             this.tabControlSelector = new MaterialSkin.Controls.MaterialTabSelector();
             this.tabControlMain = new MaterialSkin.Controls.MaterialTabControl();
             this.tabPageOptions = new System.Windows.Forms.TabPage();
+            this.oneClickGroupBox = new System.Windows.Forms.GroupBox();
+            this.toggleRegisterOneClick = new MaterialSkin.Controls.MaterialCheckBox();
             this.themeGroupBox = new System.Windows.Forms.GroupBox();
             this.radioThemeRed = new MaterialSkin.Controls.MaterialRadioButton();
             this.radioThemeBlue = new MaterialSkin.Controls.MaterialRadioButton();
@@ -71,25 +76,23 @@
             this.buttonInstall = new MaterialSkin.Controls.MaterialFlatButton();
             this.buttonViewInfo = new MaterialSkin.Controls.MaterialFlatButton();
             this.labelStatus = new MaterialSkin.Controls.MaterialLabel();
-            this.pateronLabel = new MaterialSkin.Controls.MaterialLabel();
-            this.donateModdersLabel = new MaterialSkin.Controls.MaterialLabel();
-            this.donateModdersBox = new System.Windows.Forms.PictureBox();
             this.tabPageCore.SuspendLayout();
             this.contextMenu.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.donateModdersBox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.patreonBox)).BeginInit();
             this.tabPageHelp.SuspendLayout();
             this.panelInfo.SuspendLayout();
             this.tableLayoutPanelInfo.SuspendLayout();
             this.tabControlMain.SuspendLayout();
             this.tabPageOptions.SuspendLayout();
+            this.oneClickGroupBox.SuspendLayout();
             this.themeGroupBox.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.donateModdersBox)).BeginInit();
             this.SuspendLayout();
             // 
             // textBoxDirectory
             // 
-            this.textBoxDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.textBoxDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxDirectory.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(52)))), ((int)(((byte)(73)))), ((int)(((byte)(94)))));
             this.textBoxDirectory.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -193,6 +196,45 @@
             this.tabPageCredits.TabIndex = 1;
             this.tabPageCredits.Text = "Mod Manager Credits";
             this.tabPageCredits.UseVisualStyleBackColor = true;
+            // 
+            // donateModdersBox
+            // 
+            this.donateModdersBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.donateModdersBox.Image = ((System.Drawing.Image)(resources.GetObject("donateModdersBox.Image")));
+            this.donateModdersBox.Location = new System.Drawing.Point(572, 253);
+            this.donateModdersBox.Name = "donateModdersBox";
+            this.donateModdersBox.Size = new System.Drawing.Size(217, 51);
+            this.donateModdersBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.donateModdersBox.TabIndex = 19;
+            this.donateModdersBox.TabStop = false;
+            this.donateModdersBox.Click += new System.EventHandler(this.pictureBox2_Click);
+            // 
+            // donateModdersLabel
+            // 
+            this.donateModdersLabel.AutoSize = true;
+            this.donateModdersLabel.Depth = 0;
+            this.donateModdersLabel.Font = new System.Drawing.Font("Roboto", 11F);
+            this.donateModdersLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.donateModdersLabel.Location = new System.Drawing.Point(528, 222);
+            this.donateModdersLabel.MouseState = MaterialSkin.MouseState.HOVER;
+            this.donateModdersLabel.Name = "donateModdersLabel";
+            this.donateModdersLabel.Size = new System.Drawing.Size(305, 19);
+            this.donateModdersLabel.TabIndex = 18;
+            this.donateModdersLabel.Text = "Donate to the modders that make the mods!";
+            // 
+            // pateronLabel
+            // 
+            this.pateronLabel.AutoSize = true;
+            this.pateronLabel.Depth = 0;
+            this.pateronLabel.Font = new System.Drawing.Font("Roboto", 11F);
+            this.pateronLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.pateronLabel.Location = new System.Drawing.Point(43, 222);
+            this.pateronLabel.MouseState = MaterialSkin.MouseState.HOVER;
+            this.pateronLabel.Name = "pateronLabel";
+            this.pateronLabel.Size = new System.Drawing.Size(270, 19);
+            this.pateronLabel.TabIndex = 16;
+            this.pateronLabel.Text = "Help offset server costs for BeatMods!";
+            this.pateronLabel.Click += new System.EventHandler(this.materialLabel3_Click);
             // 
             // patreonBox
             // 
@@ -336,7 +378,7 @@
             // 
             // panelInfo
             // 
-            this.panelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.panelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.panelInfo.BackColor = System.Drawing.SystemColors.Info;
             this.panelInfo.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -360,7 +402,7 @@
             // 
             // tableLayoutPanelInfo
             // 
-            this.tableLayoutPanelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tableLayoutPanelInfo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanelInfo.BackColor = System.Drawing.SystemColors.Info;
             this.tableLayoutPanelInfo.ColumnCount = 1;
@@ -390,7 +432,7 @@
             // 
             // textBoxPluginsPath
             // 
-            this.textBoxPluginsPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.textBoxPluginsPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxPluginsPath.BackColor = System.Drawing.SystemColors.Info;
             this.textBoxPluginsPath.BorderStyle = System.Windows.Forms.BorderStyle.None;
@@ -442,7 +484,7 @@
             // 
             // tabControlSelector
             // 
-            this.tabControlSelector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tabControlSelector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControlSelector.BaseTabControl = this.tabControlMain;
             this.tabControlSelector.Depth = 0;
@@ -455,8 +497,8 @@
             // 
             // tabControlMain
             // 
-            this.tabControlMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.tabControlMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControlMain.Controls.Add(this.tabPageCore);
             this.tabControlMain.Controls.Add(this.tabPageCredits);
@@ -473,6 +515,7 @@
             // 
             // tabPageOptions
             // 
+            this.tabPageOptions.Controls.Add(this.oneClickGroupBox);
             this.tabPageOptions.Controls.Add(this.themeGroupBox);
             this.tabPageOptions.Controls.Add(this.versionWarningLabel);
             this.tabPageOptions.Controls.Add(this.folderPathLabel);
@@ -485,8 +528,41 @@
             this.tabPageOptions.Text = "Options";
             this.tabPageOptions.UseVisualStyleBackColor = true;
             // 
+            // oneClickGroupBox
+            // 
+            this.oneClickGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.oneClickGroupBox.Controls.Add(this.toggleRegisterOneClick);
+            this.oneClickGroupBox.Font = new System.Drawing.Font("Segoe UI Semibold", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.oneClickGroupBox.ForeColor = System.Drawing.Color.DeepSkyBlue;
+            this.oneClickGroupBox.Location = new System.Drawing.Point(15, 207);
+            this.oneClickGroupBox.Name = "oneClickGroupBox";
+            this.oneClickGroupBox.Size = new System.Drawing.Size(829, 80);
+            this.oneClickGroupBox.TabIndex = 16;
+            this.oneClickGroupBox.TabStop = false;
+            this.oneClickGroupBox.Text = "OneClick Installer";
+            // 
+            // toggleRegisterOneClick
+            // 
+            this.toggleRegisterOneClick.AutoSize = true;
+            this.toggleRegisterOneClick.Depth = 0;
+            this.toggleRegisterOneClick.Font = new System.Drawing.Font("Roboto", 10F);
+            this.toggleRegisterOneClick.Location = new System.Drawing.Point(21, 32);
+            this.toggleRegisterOneClick.Margin = new System.Windows.Forms.Padding(0);
+            this.toggleRegisterOneClick.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.toggleRegisterOneClick.MouseState = MaterialSkin.MouseState.HOVER;
+            this.toggleRegisterOneClick.Name = "toggleRegisterOneClick";
+            this.toggleRegisterOneClick.Ripple = true;
+            this.toggleRegisterOneClick.Size = new System.Drawing.Size(297, 30);
+            this.toggleRegisterOneClick.TabIndex = 20;
+            this.toggleRegisterOneClick.Text = "Register as OneClick installer for BeatSaver";
+            this.toggleRegisterOneClick.UseVisualStyleBackColor = true;
+            this.toggleRegisterOneClick.CheckedChanged += new System.EventHandler(this.ToggleRegisterOneClick_CheckedChanged);
+            // 
             // themeGroupBox
             // 
+            this.themeGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.themeGroupBox.Controls.Add(this.radioThemeRed);
             this.themeGroupBox.Controls.Add(this.radioThemeBlue);
             this.themeGroupBox.Controls.Add(this.radioThemeOrange);
@@ -668,45 +744,6 @@
             this.labelStatus.Text = "Status: NULL";
             this.labelStatus.DoubleClick += new System.EventHandler(this.LabelStatus_DoubleClick);
             // 
-            // pateronLabel
-            // 
-            this.pateronLabel.AutoSize = true;
-            this.pateronLabel.Depth = 0;
-            this.pateronLabel.Font = new System.Drawing.Font("Roboto", 11F);
-            this.pateronLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.pateronLabel.Location = new System.Drawing.Point(43, 222);
-            this.pateronLabel.MouseState = MaterialSkin.MouseState.HOVER;
-            this.pateronLabel.Name = "pateronLabel";
-            this.pateronLabel.Size = new System.Drawing.Size(270, 19);
-            this.pateronLabel.TabIndex = 16;
-            this.pateronLabel.Text = "Help offset server costs for BeatMods!";
-            this.pateronLabel.Click += new System.EventHandler(this.materialLabel3_Click);
-            // 
-            // donateModdersLabel
-            // 
-            this.donateModdersLabel.AutoSize = true;
-            this.donateModdersLabel.Depth = 0;
-            this.donateModdersLabel.Font = new System.Drawing.Font("Roboto", 11F);
-            this.donateModdersLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.donateModdersLabel.Location = new System.Drawing.Point(528, 222);
-            this.donateModdersLabel.MouseState = MaterialSkin.MouseState.HOVER;
-            this.donateModdersLabel.Name = "donateModdersLabel";
-            this.donateModdersLabel.Size = new System.Drawing.Size(305, 19);
-            this.donateModdersLabel.TabIndex = 18;
-            this.donateModdersLabel.Text = "Donate to the modders that make the mods!";
-            // 
-            // donateModdersBox
-            // 
-            this.donateModdersBox.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.donateModdersBox.Image = ((System.Drawing.Image)(resources.GetObject("donateModdersBox.Image")));
-            this.donateModdersBox.Location = new System.Drawing.Point(572, 253);
-            this.donateModdersBox.Name = "donateModdersBox";
-            this.donateModdersBox.Size = new System.Drawing.Size(217, 51);
-            this.donateModdersBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.donateModdersBox.TabIndex = 19;
-            this.donateModdersBox.TabStop = false;
-            this.donateModdersBox.Click += new System.EventHandler(this.pictureBox2_Click);
-            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -728,6 +765,7 @@
             this.contextMenu.ResumeLayout(false);
             this.tabPageCredits.ResumeLayout(false);
             this.tabPageCredits.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.donateModdersBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.patreonBox)).EndInit();
             this.tabPageHelp.ResumeLayout(false);
             this.tabPageHelp.PerformLayout();
@@ -738,9 +776,10 @@
             this.tabControlMain.ResumeLayout(false);
             this.tabPageOptions.ResumeLayout(false);
             this.tabPageOptions.PerformLayout();
+            this.oneClickGroupBox.ResumeLayout(false);
+            this.oneClickGroupBox.PerformLayout();
             this.themeGroupBox.ResumeLayout(false);
             this.themeGroupBox.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.donateModdersBox)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -793,6 +832,8 @@
         private MaterialSkin.Controls.MaterialLabel pateronLabel;
         private MaterialSkin.Controls.MaterialLabel donateModdersLabel;
         private System.Windows.Forms.PictureBox donateModdersBox;
+        private System.Windows.Forms.GroupBox oneClickGroupBox;
+        private MaterialSkin.Controls.MaterialCheckBox toggleRegisterOneClick;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -561,15 +561,15 @@ namespace BeatSaberModManager
         {
             if (m.Msg == OneClickInstaller.WM_DL_START)
             {
-                UpdateStatus("Song download started");
+                UpdateStatus("Download started");
             }
             else if (m.Msg == OneClickInstaller.WM_DL_SUCCESS)
             {
-                UpdateStatus("Song downloaded successfully");
+                UpdateStatus("Downloaded successfully");
             }
             else if (m.Msg == OneClickInstaller.WM_DL_FAIL)
             {
-                UpdateStatus("Song download failed");
+                UpdateStatus("Download failed");
             }
             base.WndProc(ref m);
         }

--- a/BeatSaberModManager/Program.cs
+++ b/BeatSaberModManager/Program.cs
@@ -17,14 +17,13 @@ namespace BeatSaberModManager
             {
                 switch (args[i])
                 {
-                case "--install-song":
-                    Console.WriteLine("Installing: {0}", args[i + 1]);
-                    Core.OneClickInstaller.InstallSong(args[i + 1]);
-                    close = true;
-                    break;
+                    case "--install":
+                        Core.OneClickInstaller.InstallFile(args[i + 1]);
+                        close = true;
+                        break;
 
-                default:
-                    break;
+                    default:
+                        break;
                 }
             }
 
@@ -35,6 +34,5 @@ namespace BeatSaberModManager
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new FormMain());
         }
-
     }
 }

--- a/BeatSaberModManager/Program.cs
+++ b/BeatSaberModManager/Program.cs
@@ -10,12 +10,31 @@ namespace BeatSaberModManager
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
+            bool close = false;
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                case "--install-song":
+                    Console.WriteLine("Installing: {0}", args[i + 1]);
+                    Core.OneClickInstaller.InstallSong(args[i + 1]);
+                    close = true;
+                    break;
+
+                default:
+                    break;
+                }
+            }
+
+            if (close)
+                return;
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new FormMain());
         }
-        
+
     }
 }


### PR DESCRIPTION
[Do not merge yet, protocol discussions still open, issue: #21]

Basic oneclick downloading should work for songs, avatars, platforms and sabers.

When downloading a song, no new modinstaller window will open and the install will be done quietly in the background. However if one is already open a download start/success/error notification will appear in the status bar.

Windows UAC is a bit annoying since it pops up for each song install.
My solution suggestion based on some googling would be to remove the default privilege request from the manifest and instead check at startup whether the modinstaller should be loaded and restart with admin privileges (should not be noticable to the user). There are a few other weird techniques, however I'm open for discussion here. For now I haven't changed anything in this pr yet.