### PR TITLE
Save install path

### DIFF
--- a/BeatSaberModManager/Core/PathLogic.cs
+++ b/BeatSaberModManager/Core/PathLogic.cs
@@ -19,6 +19,16 @@ namespace BeatSaberModManager.Core
         
         public string GetInstallationPath()
         {
+            // Check if install path is already saved
+            if (Properties.Settings.Default.InstallPath != null)
+            {
+                if (File.Exists(Path.Combine(Properties.Settings.Default.InstallPath, AppFileName)))
+                {
+                    installPath = Properties.Settings.Default.InstallPath;
+                    return installPath;
+                }
+            }
+
             string steam = GetSteamLocation();
             if (steam != null)
             {

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -464,6 +464,8 @@ namespace BeatSaberModManager
         {
             textBoxDirectory.Text = path.ManualFind();
             installer.installDirectory = textBoxDirectory.Text;
+            Properties.Settings.Default.InstallPath = textBoxDirectory.Text;
+            Properties.Settings.Default.Save();
         }
 
         private void ToggleTheme_CheckedChanged(object sender, EventArgs e)

--- a/BeatSaberModManager/Properties/Settings.Designer.cs
+++ b/BeatSaberModManager/Properties/Settings.Designer.cs
@@ -70,5 +70,17 @@ namespace BeatSaberModManager.Properties {
                 this["UpgradeRequired"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string InstallPath {
+            get {
+                return ((string)(this["InstallPath"]));
+            }
+            set {
+                this["InstallPath"] = value;
+            }
+        }
     }
 }

--- a/BeatSaberModManager/Properties/Settings.settings
+++ b/BeatSaberModManager/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="UpgradeRequired" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="InstallPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/BeatSaberModManager/app.config
+++ b/BeatSaberModManager/app.config
@@ -19,6 +19,9 @@
             <setting name="UpgradeRequired" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="InstallPath" serializeAs="String">
+                <value />
+            </setting>
         </BeatSaberModManager.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
This should save the install path after it has been selected.
This will prevent the installer from asking for the path every time the app is launched.
If the path is not found within the saved settings, it will attempt to find it as usual.

Closes #28 