### PR TITLE
Add support for mirrors

### DIFF
--- a/BeatSaberModManager/Core/Helper.cs
+++ b/BeatSaberModManager/Core/Helper.cs
@@ -12,7 +12,7 @@ namespace BeatSaberModManager.Core
     public static class Helper
     {
 
-        public static string Get(string URL) {
+        public static string Get(string URL, bool releases = false) {
 
             try {
                 HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(URL);
@@ -27,7 +27,10 @@ namespace BeatSaberModManager.Core
             }
             catch (Exception ex) {
                 MessageBox.Show($"Error trying to access: {URL}\n\n{ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Environment.Exit(0);
+                if (!releases)
+                {
+                    Environment.Exit(0);
+                }
                 return null;
             }
         }


### PR DESCRIPTION
If an error occurs while retrieving the mod list from BeatMods, the installer will try every mirror until one works or none are left. Only then will it close itself, instead of on the first failed attempt.
The mods are downloaded from the same place as the mod list to ensure no conflicts occur.

I plan on creating a node module for easily creating mirrors and verifying their integrity, probably next week.