### PR TITLE
Updated installer to not force-install BSIPA

### DIFF
--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -61,20 +61,13 @@ namespace BeatSaberModManager.Core
                     }
                 }
 
-                if (bsipa != null)
-                    Process.Start(new ProcessStartInfo
-                    {
-                        FileName = Path.Combine(installDirectory, "IPA.exe"),
-                        WorkingDirectory = installDirectory,
-                        Arguments = "-fn"
-                    }).WaitForExit();
-                else
-                    Process.Start(new ProcessStartInfo
-                    {
-                        FileName = Path.Combine(installDirectory, "IPA.exe"),
-                        WorkingDirectory = installDirectory,
-                        Arguments = Quoted(Path.Combine(installDirectory, "Beat Saber.exe"))
-                    }).WaitForExit();
+                // Only ever going to be downloading BSIPA
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = Path.Combine(installDirectory, "IPA.exe"),
+                    WorkingDirectory = installDirectory,
+                    Arguments = "-n"
+                }).WaitForExit();
                 
                 StatusUpdate("Install complete!");
             } catch (Exception ex)

--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -35,7 +35,7 @@ namespace BeatSaberModManager.Core
                 StatusUpdate("Starting install sequence...");
 
                 ReleaseInfo bsipa = null;
-                if ((bsipa = releases.Find(release => release.name.ToLower() == "bsipa")) != null)
+                if ((bsipa = releases.Find(release => release.name.ToLower() == "BSIPA")) != null)
                 {
                     StatusUpdate($"Downloading...{bsipa.title}");
                     byte[] file = Helper.GetFile(bsipa.downloadLink);
@@ -46,7 +46,7 @@ namespace BeatSaberModManager.Core
                     releases.Remove(bsipa); // don't want to double down
                 }
 
-                var toInstall = bsipa == null ? installDirectory : Path.Combine(installDirectory, "IPA", "Pending");
+                var toInstall = Path.Combine(installDirectory, "IPA", "Pending");
                 Directory.CreateDirectory(toInstall);
 
                 foreach (ReleaseInfo release in releases)

--- a/BeatSaberModManager/Core/InstallerLogic.cs
+++ b/BeatSaberModManager/Core/InstallerLogic.cs
@@ -35,7 +35,7 @@ namespace BeatSaberModManager.Core
                 StatusUpdate("Starting install sequence...");
 
                 ReleaseInfo bsipa = null;
-                if ((bsipa = releases.Find(release => release.name.ToLower() == "BSIPA")) != null)
+                if ((bsipa = releases.Find(release => release.name.ToLower() == "bsipa")) != null)
                 {
                     StatusUpdate($"Downloading...{bsipa.title}");
                     byte[] file = Helper.GetFile(bsipa.downloadLink);


### PR DESCRIPTION
One of the more recent changes to the BSIPA installer makes it check if there is a newer version already installed, unless the `-f` flag is set. This both fixes the install process, and removes that flag.