### PR TITLE
Fixed InstallPath not saving on start up

### DIFF
--- a/BeatSaberModManager/Core/PathLogic.cs
+++ b/BeatSaberModManager/Core/PathLogic.cs
@@ -157,6 +157,8 @@ namespace BeatSaberModManager.Core
                             FormPlatformSelect selector = new FormPlatformSelect(this);
                             selector.ShowDialog();
                             found = true;
+                            Properties.Settings.Default.InstallPath = path;
+                            Properties.Settings.Default.Save();
                             return path;
                         }
                         else


### PR DESCRIPTION
Fixes a bug where the InstallPath doesn't save if you select it on start up