### PR TITLE
Game version support

### DIFF
--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -100,19 +100,19 @@ namespace BeatSaberModManager.Core
 
                         CreateRelease(
                             new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
-                            current["description"], current["link"], 0, "0.13.2", steam["url"],
+                            current["description"], current["link"], 0, current["gameVersion"], steam["url"],
                             current["category"], Platform.Steam, dependsOn, conflictsWith));
 
                         CreateRelease(
                             new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
-                            current["description"], current["link"], 0, "0.13.2", oculus["url"],
+                            current["description"], current["link"], 0, current["gameVersion"], oculus["url"],
                             current["category"], Platform.Oculus, dependsOn, conflictsWith));
                     }
                     else
                     {
                         CreateRelease(
                             new ReleaseInfo(current["name"], current["name"], current["version"], current["author"]["username"],
-                            current["description"], current["link"], 0, "0.13.2", files[0]["url"],
+                            current["description"], current["link"], 0, current["gameVersion"], files[0]["url"],
                             current["category"], Platform.Default, dependsOn, conflictsWith));
                     }
                 }
@@ -157,8 +157,8 @@ namespace BeatSaberModManager.Core
 
         private void CreateRelease(ReleaseInfo release)
         {
-            //if (release.gameVersion != selectedGameVersion.value)
-            //    return;
+            if (release.gameVersion != selectedGameVersion.value)
+                return;
 
             ReleaseInfo current = releases.Find(x => x.name == release.name);
             if (current == null)

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -43,7 +43,7 @@ namespace BeatSaberModManager.Core
             {
                 var current = gameVersionsRaw[i];
 
-                GameVersion gv = new GameVersion(current["value"]);
+                GameVersion gv = new GameVersion(current.Value);
 
                 gvList.Add(gv);
             }

--- a/BeatSaberModManager/Core/RemoteLogic.cs
+++ b/BeatSaberModManager/Core/RemoteLogic.cs
@@ -35,7 +35,7 @@ namespace BeatSaberModManager.Core
 
         public void GetGameVersions()
         {
-            string raw = Fetch($"{ApiURL}/site/gameversions");
+            string raw = Fetch($"{ApiURL}/version");
             var gameVersionsRaw = JSON.Parse(raw);
 
             List<GameVersion> gvList = new List<GameVersion>();
@@ -43,11 +43,7 @@ namespace BeatSaberModManager.Core
             {
                 var current = gameVersionsRaw[i];
 
-                GameVersion gv = new GameVersion(
-                    current["id"],
-                    current["value"],
-                    current["manifest"]
-                );
+                GameVersion gv = new GameVersion(current["value"]);
 
                 gvList.Add(gv);
             }

--- a/BeatSaberModManager/DataModels/GameVersion.cs
+++ b/BeatSaberModManager/DataModels/GameVersion.cs
@@ -8,15 +8,11 @@ namespace BeatSaberModManager.DataModels
 {
     public struct GameVersion
     {
-        public string id;
         public string value;
-        public string manifest;
 
-        public GameVersion(string _id, string _value, string _manifest)
+        public GameVersion(string _value)
         {
-            id = _id;
             value = _value;
-            manifest = _manifest;
         }
     }
 }

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -594,7 +594,7 @@
             this.extrasGroupBox.Controls.Add(this.openSettingsFolder);
             this.extrasGroupBox.Font = new System.Drawing.Font("Segoe UI Semibold", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.extrasGroupBox.ForeColor = System.Drawing.Color.DeepSkyBlue;
-            this.extrasGroupBox.Location = new System.Drawing.Point(15, 293);
+            this.extrasGroupBox.Location = new System.Drawing.Point(16, 217);
             this.extrasGroupBox.Name = "extrasGroupBox";
             this.extrasGroupBox.Size = new System.Drawing.Size(829, 105);
             this.extrasGroupBox.TabIndex = 21;
@@ -653,7 +653,7 @@
             this.oneClickGroupBox.Controls.Add(this.toggleRegisterOneClick);
             this.oneClickGroupBox.Font = new System.Drawing.Font("Segoe UI Semibold", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.oneClickGroupBox.ForeColor = System.Drawing.Color.DeepSkyBlue;
-            this.oneClickGroupBox.Location = new System.Drawing.Point(15, 207);
+            this.oneClickGroupBox.Location = new System.Drawing.Point(16, 131);
             this.oneClickGroupBox.Name = "oneClickGroupBox";
             this.oneClickGroupBox.Size = new System.Drawing.Size(829, 80);
             this.oneClickGroupBox.TabIndex = 16;
@@ -689,7 +689,7 @@
             this.themeGroupBox.Controls.Add(this.radioThemeBlueGrey);
             this.themeGroupBox.Font = new System.Drawing.Font("Segoe UI Semibold", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.themeGroupBox.ForeColor = System.Drawing.Color.DeepSkyBlue;
-            this.themeGroupBox.Location = new System.Drawing.Point(15, 79);
+            this.themeGroupBox.Location = new System.Drawing.Point(16, 3);
             this.themeGroupBox.Name = "themeGroupBox";
             this.themeGroupBox.Size = new System.Drawing.Size(829, 122);
             this.themeGroupBox.TabIndex = 15;

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -62,6 +62,7 @@
             this.tabControlSelector = new MaterialSkin.Controls.MaterialTabSelector();
             this.tabControlMain = new MaterialSkin.Controls.MaterialTabControl();
             this.tabPageOptions = new System.Windows.Forms.TabPage();
+            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
             this.comboBox_gameVersions = new System.Windows.Forms.ComboBox();
             this.extrasGroupBox = new System.Windows.Forms.GroupBox();
             this.platformLabel = new MaterialSkin.Controls.MaterialLabel();
@@ -80,7 +81,6 @@
             this.buttonInstall = new MaterialSkin.Controls.MaterialFlatButton();
             this.buttonViewInfo = new MaterialSkin.Controls.MaterialFlatButton();
             this.labelStatus = new MaterialSkin.Controls.MaterialLabel();
-            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
             this.tabPageCore.SuspendLayout();
             this.contextMenu.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
@@ -524,6 +524,19 @@
             this.tabPageOptions.Text = "Options";
             this.tabPageOptions.UseVisualStyleBackColor = true;
             // 
+            // materialLabel3
+            // 
+            this.materialLabel3.AutoSize = true;
+            this.materialLabel3.Depth = 0;
+            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel3.Location = new System.Drawing.Point(746, 19);
+            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel3.Name = "materialLabel3";
+            this.materialLabel3.Size = new System.Drawing.Size(104, 19);
+            this.materialLabel3.TabIndex = 23;
+            this.materialLabel3.Text = "Game Version";
+            // 
             // comboBox_gameVersions
             // 
             this.comboBox_gameVersions.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -810,19 +823,6 @@
             this.labelStatus.TabIndex = 18;
             this.labelStatus.Text = "Status: NULL";
             this.labelStatus.DoubleClick += new System.EventHandler(this.LabelStatus_DoubleClick);
-            // 
-            // materialLabel3
-            // 
-            this.materialLabel3.AutoSize = true;
-            this.materialLabel3.Depth = 0;
-            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
-            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.materialLabel3.Location = new System.Drawing.Point(746, 19);
-            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
-            this.materialLabel3.Name = "materialLabel3";
-            this.materialLabel3.Size = new System.Drawing.Size(104, 19);
-            this.materialLabel3.TabIndex = 23;
-            this.materialLabel3.Text = "Game Version";
             // 
             // FormMain
             // 

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -58,13 +58,13 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
             this.helpInfoLabel3 = new System.Windows.Forms.Label();
-            this.versionWarningLabel = new System.Windows.Forms.Label();
             this.browseInstallationButton = new MaterialSkin.Controls.MaterialRaisedButton();
             this.tabControlSelector = new MaterialSkin.Controls.MaterialTabSelector();
             this.tabControlMain = new MaterialSkin.Controls.MaterialTabControl();
             this.tabPageOptions = new System.Windows.Forms.TabPage();
-            this.platformLabel = new MaterialSkin.Controls.MaterialLabel();
+            this.comboBox_gameVersions = new System.Windows.Forms.ComboBox();
             this.extrasGroupBox = new System.Windows.Forms.GroupBox();
+            this.platformLabel = new MaterialSkin.Controls.MaterialLabel();
             this.resetSettingsButton = new MaterialSkin.Controls.MaterialFlatButton();
             this.openSettingsFolder = new MaterialSkin.Controls.MaterialFlatButton();
             this.oneClickGroupBox = new System.Windows.Forms.GroupBox();
@@ -80,6 +80,7 @@
             this.buttonInstall = new MaterialSkin.Controls.MaterialFlatButton();
             this.buttonViewInfo = new MaterialSkin.Controls.MaterialFlatButton();
             this.labelStatus = new MaterialSkin.Controls.MaterialLabel();
+            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
             this.tabPageCore.SuspendLayout();
             this.contextMenu.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
@@ -106,7 +107,7 @@
             this.textBoxDirectory.ForeColor = System.Drawing.Color.WhiteSmoke;
             this.textBoxDirectory.Location = new System.Drawing.Point(15, 41);
             this.textBoxDirectory.Name = "textBoxDirectory";
-            this.textBoxDirectory.Size = new System.Drawing.Size(797, 26);
+            this.textBoxDirectory.Size = new System.Drawing.Size(687, 26);
             this.textBoxDirectory.TabIndex = 0;
             this.textBoxDirectory.TextChanged += new System.EventHandler(this.textBoxDirectory_TextChanged);
             // 
@@ -460,24 +461,12 @@
             this.helpInfoLabel3.TabIndex = 3;
             this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
-            // versionWarningLabel
-            // 
-            this.versionWarningLabel.AutoSize = true;
-            this.versionWarningLabel.BackColor = System.Drawing.Color.Transparent;
-            this.versionWarningLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.versionWarningLabel.ForeColor = System.Drawing.Color.Tomato;
-            this.versionWarningLabel.Location = new System.Drawing.Point(179, 22);
-            this.versionWarningLabel.Name = "versionWarningLabel";
-            this.versionWarningLabel.Size = new System.Drawing.Size(69, 15);
-            this.versionWarningLabel.TabIndex = 11;
-            this.versionWarningLabel.Text = "v0.13.2 only";
-            // 
             // browseInstallationButton
             // 
             this.browseInstallationButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.browseInstallationButton.Depth = 0;
             this.browseInstallationButton.Font = new System.Drawing.Font("Segoe UI", 8F);
-            this.browseInstallationButton.Location = new System.Drawing.Point(818, 40);
+            this.browseInstallationButton.Location = new System.Drawing.Point(708, 40);
             this.browseInstallationButton.MouseState = MaterialSkin.MouseState.HOVER;
             this.browseInstallationButton.Name = "browseInstallationButton";
             this.browseInstallationButton.Primary = true;
@@ -520,10 +509,11 @@
             // 
             // tabPageOptions
             // 
+            this.tabPageOptions.Controls.Add(this.materialLabel3);
+            this.tabPageOptions.Controls.Add(this.comboBox_gameVersions);
             this.tabPageOptions.Controls.Add(this.extrasGroupBox);
             this.tabPageOptions.Controls.Add(this.oneClickGroupBox);
             this.tabPageOptions.Controls.Add(this.themeGroupBox);
-            this.tabPageOptions.Controls.Add(this.versionWarningLabel);
             this.tabPageOptions.Controls.Add(this.folderPathLabel);
             this.tabPageOptions.Controls.Add(this.textBoxDirectory);
             this.tabPageOptions.Controls.Add(this.browseInstallationButton);
@@ -534,18 +524,15 @@
             this.tabPageOptions.Text = "Options";
             this.tabPageOptions.UseVisualStyleBackColor = true;
             // 
-            // platformLabel
+            // comboBox_gameVersions
             // 
-            this.platformLabel.AutoSize = true;
-            this.platformLabel.Depth = 0;
-            this.platformLabel.Font = new System.Drawing.Font("Roboto", 11F);
-            this.platformLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.platformLabel.Location = new System.Drawing.Point(17, 35);
-            this.platformLabel.MouseState = MaterialSkin.MouseState.HOVER;
-            this.platformLabel.Name = "platformLabel";
-            this.platformLabel.Size = new System.Drawing.Size(123, 19);
-            this.platformLabel.TabIndex = 22;
-            this.platformLabel.Text = "Platform: Default";
+            this.comboBox_gameVersions.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comboBox_gameVersions.FormattingEnabled = true;
+            this.comboBox_gameVersions.Location = new System.Drawing.Point(750, 40);
+            this.comboBox_gameVersions.Name = "comboBox_gameVersions";
+            this.comboBox_gameVersions.Size = new System.Drawing.Size(100, 27);
+            this.comboBox_gameVersions.TabIndex = 22;
+            this.comboBox_gameVersions.SelectedIndexChanged += new System.EventHandler(this.comboBox_gameVersions_SelectedIndexChanged);
             // 
             // extrasGroupBox
             // 
@@ -562,6 +549,19 @@
             this.extrasGroupBox.TabIndex = 21;
             this.extrasGroupBox.TabStop = false;
             this.extrasGroupBox.Text = "Debugging";
+            // 
+            // platformLabel
+            // 
+            this.platformLabel.AutoSize = true;
+            this.platformLabel.Depth = 0;
+            this.platformLabel.Font = new System.Drawing.Font("Roboto", 11F);
+            this.platformLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.platformLabel.Location = new System.Drawing.Point(17, 35);
+            this.platformLabel.MouseState = MaterialSkin.MouseState.HOVER;
+            this.platformLabel.Name = "platformLabel";
+            this.platformLabel.Size = new System.Drawing.Size(123, 19);
+            this.platformLabel.TabIndex = 22;
+            this.platformLabel.Text = "Platform: Default";
             // 
             // resetSettingsButton
             // 
@@ -811,6 +811,19 @@
             this.labelStatus.Text = "Status: NULL";
             this.labelStatus.DoubleClick += new System.EventHandler(this.LabelStatus_DoubleClick);
             // 
+            // materialLabel3
+            // 
+            this.materialLabel3.AutoSize = true;
+            this.materialLabel3.Depth = 0;
+            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel3.Location = new System.Drawing.Point(746, 19);
+            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel3.Name = "materialLabel3";
+            this.materialLabel3.Size = new System.Drawing.Size(104, 19);
+            this.materialLabel3.TabIndex = 23;
+            this.materialLabel3.Text = "Game Version";
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -864,7 +877,6 @@
         private System.Windows.Forms.TabPage tabPageCredits;
         private System.Windows.Forms.ColumnHeader columnHeaderVersion;
         private System.Windows.Forms.TabPage tabPageHelp;
-        private System.Windows.Forms.Label versionWarningLabel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelInfo;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TextBox textBoxPluginsPath;
@@ -907,6 +919,8 @@
         private MaterialSkin.Controls.MaterialFlatButton openSettingsFolder;
         private MaterialSkin.Controls.MaterialFlatButton resetSettingsButton;
         private MaterialSkin.Controls.MaterialLabel platformLabel;
+        private System.Windows.Forms.ComboBox comboBox_gameVersions;
+        private MaterialSkin.Controls.MaterialLabel materialLabel3;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.Designer.cs
+++ b/BeatSaberModManager/Forms/FormMain.Designer.cs
@@ -29,8 +29,14 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormMain));
-            this.textBoxDirectory = new System.Windows.Forms.TextBox();
             this.tabPageCore = new System.Windows.Forms.TabPage();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
+            this.comboBox_gameVersions = new System.Windows.Forms.ComboBox();
+            this.folderPathLabel = new MaterialSkin.Controls.MaterialLabel();
+            this.textBoxDirectory = new System.Windows.Forms.TextBox();
+            this.browseInstallationButton = new MaterialSkin.Controls.MaterialRaisedButton();
             this.listViewMods = new System.Windows.Forms.ListView();
             this.columnHeaderName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeaderAuthor = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -58,12 +64,9 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxPluginsPath = new System.Windows.Forms.TextBox();
             this.helpInfoLabel3 = new System.Windows.Forms.Label();
-            this.browseInstallationButton = new MaterialSkin.Controls.MaterialRaisedButton();
             this.tabControlSelector = new MaterialSkin.Controls.MaterialTabSelector();
             this.tabControlMain = new MaterialSkin.Controls.MaterialTabControl();
             this.tabPageOptions = new System.Windows.Forms.TabPage();
-            this.materialLabel3 = new MaterialSkin.Controls.MaterialLabel();
-            this.comboBox_gameVersions = new System.Windows.Forms.ComboBox();
             this.extrasGroupBox = new System.Windows.Forms.GroupBox();
             this.platformLabel = new MaterialSkin.Controls.MaterialLabel();
             this.resetSettingsButton = new MaterialSkin.Controls.MaterialFlatButton();
@@ -77,11 +80,12 @@
             this.radioThemeGreen = new MaterialSkin.Controls.MaterialRadioButton();
             this.toggleTheme = new MaterialSkin.Controls.MaterialCheckBox();
             this.radioThemeBlueGrey = new MaterialSkin.Controls.MaterialRadioButton();
-            this.folderPathLabel = new MaterialSkin.Controls.MaterialLabel();
             this.buttonInstall = new MaterialSkin.Controls.MaterialFlatButton();
             this.buttonViewInfo = new MaterialSkin.Controls.MaterialFlatButton();
             this.labelStatus = new MaterialSkin.Controls.MaterialLabel();
             this.tabPageCore.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.contextMenu.SuspendLayout();
             this.tabPageCredits.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.donateModdersBox)).BeginInit();
@@ -96,6 +100,81 @@
             this.themeGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
+            // tabPageCore
+            // 
+            this.tabPageCore.Controls.Add(this.tableLayoutPanel1);
+            this.tabPageCore.Location = new System.Drawing.Point(4, 22);
+            this.tabPageCore.Name = "tabPageCore";
+            this.tabPageCore.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageCore.Size = new System.Drawing.Size(860, 401);
+            this.tabPageCore.TabIndex = 0;
+            this.tabPageCore.Text = "Plugins";
+            this.tabPageCore.UseVisualStyleBackColor = true;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.panel1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.listViewMods, 0, 1);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 70F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(854, 395);
+            this.tableLayoutPanel1.TabIndex = 2;
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.materialLabel3);
+            this.panel1.Controls.Add(this.comboBox_gameVersions);
+            this.panel1.Controls.Add(this.folderPathLabel);
+            this.panel1.Controls.Add(this.textBoxDirectory);
+            this.panel1.Controls.Add(this.browseInstallationButton);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(3, 3);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(848, 64);
+            this.panel1.TabIndex = 3;
+            // 
+            // materialLabel3
+            // 
+            this.materialLabel3.AutoSize = true;
+            this.materialLabel3.Depth = 0;
+            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel3.Location = new System.Drawing.Point(739, 7);
+            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel3.Name = "materialLabel3";
+            this.materialLabel3.Size = new System.Drawing.Size(104, 19);
+            this.materialLabel3.TabIndex = 33;
+            this.materialLabel3.Text = "Game Version";
+            // 
+            // comboBox_gameVersions
+            // 
+            this.comboBox_gameVersions.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comboBox_gameVersions.FormattingEnabled = true;
+            this.comboBox_gameVersions.Location = new System.Drawing.Point(743, 28);
+            this.comboBox_gameVersions.Name = "comboBox_gameVersions";
+            this.comboBox_gameVersions.Size = new System.Drawing.Size(100, 27);
+            this.comboBox_gameVersions.TabIndex = 32;
+            this.comboBox_gameVersions.SelectedIndexChanged += new System.EventHandler(this.comboBox_gameVersions_SelectedIndexChanged);
+            // 
+            // folderPathLabel
+            // 
+            this.folderPathLabel.AutoSize = true;
+            this.folderPathLabel.Depth = 0;
+            this.folderPathLabel.Font = new System.Drawing.Font("Roboto", 11F);
+            this.folderPathLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.folderPathLabel.Location = new System.Drawing.Point(5, 7);
+            this.folderPathLabel.MouseState = MaterialSkin.MouseState.HOVER;
+            this.folderPathLabel.Name = "folderPathLabel";
+            this.folderPathLabel.Size = new System.Drawing.Size(165, 19);
+            this.folderPathLabel.TabIndex = 31;
+            this.folderPathLabel.Text = "Beat Saber Folder Path:";
+            // 
             // textBoxDirectory
             // 
             this.textBoxDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -105,22 +184,26 @@
             this.textBoxDirectory.Enabled = false;
             this.textBoxDirectory.Font = new System.Drawing.Font("Consolas", 12F);
             this.textBoxDirectory.ForeColor = System.Drawing.Color.WhiteSmoke;
-            this.textBoxDirectory.Location = new System.Drawing.Point(15, 41);
+            this.textBoxDirectory.Location = new System.Drawing.Point(8, 29);
             this.textBoxDirectory.Name = "textBoxDirectory";
-            this.textBoxDirectory.Size = new System.Drawing.Size(687, 26);
-            this.textBoxDirectory.TabIndex = 0;
+            this.textBoxDirectory.Size = new System.Drawing.Size(681, 26);
+            this.textBoxDirectory.TabIndex = 29;
             this.textBoxDirectory.TextChanged += new System.EventHandler(this.textBoxDirectory_TextChanged);
             // 
-            // tabPageCore
+            // browseInstallationButton
             // 
-            this.tabPageCore.Controls.Add(this.listViewMods);
-            this.tabPageCore.Location = new System.Drawing.Point(4, 22);
-            this.tabPageCore.Name = "tabPageCore";
-            this.tabPageCore.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageCore.Size = new System.Drawing.Size(860, 401);
-            this.tabPageCore.TabIndex = 0;
-            this.tabPageCore.Text = "Plugins";
-            this.tabPageCore.UseVisualStyleBackColor = true;
+            this.browseInstallationButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.browseInstallationButton.Depth = 0;
+            this.browseInstallationButton.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.browseInstallationButton.Location = new System.Drawing.Point(695, 28);
+            this.browseInstallationButton.MouseState = MaterialSkin.MouseState.HOVER;
+            this.browseInstallationButton.Name = "browseInstallationButton";
+            this.browseInstallationButton.Primary = true;
+            this.browseInstallationButton.Size = new System.Drawing.Size(26, 26);
+            this.browseInstallationButton.TabIndex = 30;
+            this.browseInstallationButton.Text = "..";
+            this.browseInstallationButton.UseVisualStyleBackColor = true;
+            this.browseInstallationButton.Click += new System.EventHandler(this.BrowseInstallationButton_Click);
             // 
             // listViewMods
             // 
@@ -134,14 +217,12 @@
             this.listViewMods.Dock = System.Windows.Forms.DockStyle.Fill;
             this.listViewMods.Font = new System.Drawing.Font("Segoe UI", 10F);
             this.listViewMods.FullRowSelect = true;
-            this.listViewMods.Location = new System.Drawing.Point(3, 3);
+            this.listViewMods.Location = new System.Drawing.Point(3, 73);
             this.listViewMods.Name = "listViewMods";
-            this.listViewMods.Size = new System.Drawing.Size(854, 395);
-            this.listViewMods.TabIndex = 0;
+            this.listViewMods.Size = new System.Drawing.Size(848, 319);
+            this.listViewMods.TabIndex = 2;
             this.listViewMods.UseCompatibleStateImageBehavior = false;
             this.listViewMods.View = System.Windows.Forms.View.Details;
-            this.listViewMods.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.listViewMods_ItemChecked);
-            this.listViewMods.SelectedIndexChanged += new System.EventHandler(this.listViewMods_SelectedIndexChanged);
             // 
             // columnHeaderName
             // 
@@ -461,21 +542,6 @@
             this.helpInfoLabel3.TabIndex = 3;
             this.helpInfoLabel3.Text = "You can uninstall mods by removing the .dll from that folder.";
             // 
-            // browseInstallationButton
-            // 
-            this.browseInstallationButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.browseInstallationButton.Depth = 0;
-            this.browseInstallationButton.Font = new System.Drawing.Font("Segoe UI", 8F);
-            this.browseInstallationButton.Location = new System.Drawing.Point(708, 40);
-            this.browseInstallationButton.MouseState = MaterialSkin.MouseState.HOVER;
-            this.browseInstallationButton.Name = "browseInstallationButton";
-            this.browseInstallationButton.Primary = true;
-            this.browseInstallationButton.Size = new System.Drawing.Size(26, 26);
-            this.browseInstallationButton.TabIndex = 13;
-            this.browseInstallationButton.Text = "..";
-            this.browseInstallationButton.UseVisualStyleBackColor = true;
-            this.browseInstallationButton.Click += new System.EventHandler(this.BrowseInstallationButton_Click);
-            // 
             // tabControlSelector
             // 
             this.tabControlSelector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -509,43 +575,15 @@
             // 
             // tabPageOptions
             // 
-            this.tabPageOptions.Controls.Add(this.materialLabel3);
-            this.tabPageOptions.Controls.Add(this.comboBox_gameVersions);
             this.tabPageOptions.Controls.Add(this.extrasGroupBox);
             this.tabPageOptions.Controls.Add(this.oneClickGroupBox);
             this.tabPageOptions.Controls.Add(this.themeGroupBox);
-            this.tabPageOptions.Controls.Add(this.folderPathLabel);
-            this.tabPageOptions.Controls.Add(this.textBoxDirectory);
-            this.tabPageOptions.Controls.Add(this.browseInstallationButton);
             this.tabPageOptions.Location = new System.Drawing.Point(4, 22);
             this.tabPageOptions.Name = "tabPageOptions";
             this.tabPageOptions.Size = new System.Drawing.Size(860, 401);
             this.tabPageOptions.TabIndex = 3;
             this.tabPageOptions.Text = "Options";
             this.tabPageOptions.UseVisualStyleBackColor = true;
-            // 
-            // materialLabel3
-            // 
-            this.materialLabel3.AutoSize = true;
-            this.materialLabel3.Depth = 0;
-            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
-            this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.materialLabel3.Location = new System.Drawing.Point(746, 19);
-            this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
-            this.materialLabel3.Name = "materialLabel3";
-            this.materialLabel3.Size = new System.Drawing.Size(104, 19);
-            this.materialLabel3.TabIndex = 23;
-            this.materialLabel3.Text = "Game Version";
-            // 
-            // comboBox_gameVersions
-            // 
-            this.comboBox_gameVersions.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.comboBox_gameVersions.FormattingEnabled = true;
-            this.comboBox_gameVersions.Location = new System.Drawing.Point(750, 40);
-            this.comboBox_gameVersions.Name = "comboBox_gameVersions";
-            this.comboBox_gameVersions.Size = new System.Drawing.Size(100, 27);
-            this.comboBox_gameVersions.TabIndex = 22;
-            this.comboBox_gameVersions.SelectedIndexChanged += new System.EventHandler(this.comboBox_gameVersions_SelectedIndexChanged);
             // 
             // extrasGroupBox
             // 
@@ -762,19 +800,6 @@
             this.radioThemeBlueGrey.UseVisualStyleBackColor = true;
             this.radioThemeBlueGrey.CheckedChanged += new System.EventHandler(this.RadioThemeBlueGrey_CheckedChanged);
             // 
-            // folderPathLabel
-            // 
-            this.folderPathLabel.AutoSize = true;
-            this.folderPathLabel.Depth = 0;
-            this.folderPathLabel.Font = new System.Drawing.Font("Roboto", 11F);
-            this.folderPathLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.folderPathLabel.Location = new System.Drawing.Point(12, 19);
-            this.folderPathLabel.MouseState = MaterialSkin.MouseState.HOVER;
-            this.folderPathLabel.Name = "folderPathLabel";
-            this.folderPathLabel.Size = new System.Drawing.Size(165, 19);
-            this.folderPathLabel.TabIndex = 14;
-            this.folderPathLabel.Text = "Beat Saber Folder Path:";
-            // 
             // buttonInstall
             // 
             this.buttonInstall.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
@@ -842,6 +867,9 @@
             this.Text = "Beat Saber Mod Manager";
             this.Load += new System.EventHandler(this.FormMain_Load);
             this.tabPageCore.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.contextMenu.ResumeLayout(false);
             this.tabPageCredits.ResumeLayout(false);
             this.tabPageCredits.PerformLayout();
@@ -855,7 +883,6 @@
             this.tableLayoutPanelInfo.PerformLayout();
             this.tabControlMain.ResumeLayout(false);
             this.tabPageOptions.ResumeLayout(false);
-            this.tabPageOptions.PerformLayout();
             this.extrasGroupBox.ResumeLayout(false);
             this.extrasGroupBox.PerformLayout();
             this.oneClickGroupBox.ResumeLayout(false);
@@ -868,14 +895,8 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.TextBox textBoxDirectory;
         private System.Windows.Forms.TabPage tabPageCore;
-        private System.Windows.Forms.ListView listViewMods;
-        private System.Windows.Forms.ColumnHeader columnHeaderName;
-        private System.Windows.Forms.ColumnHeader columnHeaderAuthor;
         private System.Windows.Forms.TabPage tabPageCredits;
-        private System.Windows.Forms.ColumnHeader columnHeaderVersion;
         private System.Windows.Forms.TabPage tabPageHelp;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanelInfo;
         private System.Windows.Forms.Label label2;
@@ -883,7 +904,6 @@
         private System.Windows.Forms.Label helpInfoLabel3;
         private System.Windows.Forms.Label helpInfoLabel1;
         private System.Windows.Forms.Panel panelInfo;
-        private MaterialSkin.Controls.MaterialRaisedButton browseInstallationButton;
         private MaterialSkin.Controls.MaterialTabSelector tabControlSelector;
         private MaterialSkin.Controls.MaterialTabControl tabControlMain;
         private System.Windows.Forms.TabPage tabPageOptions;
@@ -891,7 +911,6 @@
         private MaterialSkin.Controls.MaterialFlatButton buttonInstall;
         private MaterialSkin.Controls.MaterialFlatButton buttonViewInfo;
         private MaterialSkin.Controls.MaterialLabel labelStatus;
-        private MaterialSkin.Controls.MaterialLabel folderPathLabel;
         private MaterialSkin.Controls.MaterialLabel materialLabel1;
         private MaterialSkin.Controls.MaterialRaisedButton creditBeatmods;
         private MaterialSkin.Controls.MaterialRaisedButton creditVanZeben;
@@ -919,8 +938,17 @@
         private MaterialSkin.Controls.MaterialFlatButton openSettingsFolder;
         private MaterialSkin.Controls.MaterialFlatButton resetSettingsButton;
         private MaterialSkin.Controls.MaterialLabel platformLabel;
-        private System.Windows.Forms.ComboBox comboBox_gameVersions;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Panel panel1;
         private MaterialSkin.Controls.MaterialLabel materialLabel3;
+        private System.Windows.Forms.ComboBox comboBox_gameVersions;
+        private MaterialSkin.Controls.MaterialLabel folderPathLabel;
+        private System.Windows.Forms.TextBox textBoxDirectory;
+        private MaterialSkin.Controls.MaterialRaisedButton browseInstallationButton;
+        private System.Windows.Forms.ListView listViewMods;
+        private System.Windows.Forms.ColumnHeader columnHeaderName;
+        private System.Windows.Forms.ColumnHeader columnHeaderAuthor;
+        private System.Windows.Forms.ColumnHeader columnHeaderVersion;
     }
 }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -148,7 +148,9 @@ namespace BeatSaberModManager
                     "You have Beat Saber version " + installedVersion + " installed,\n" +
                     "but it is not supported by Beat Mods!\n\n" +
                     "Beat Mods only supports the following versions:\n" +
-                    allVersionsString;
+                    allVersionsString +
+                    "\n\n" +
+                    "Install mods at your own risk!";
                 MessageBox.Show(versionErrorMessage, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -128,24 +128,37 @@ namespace BeatSaberModManager
 
             string installedVersion = GetInstalledGameVersion();
             int installedVersionIndex = -1;
+            string allVersionsString = "";
+            string latestVersion = remote.gameVersions[0].value;
             for (int i = 0; i < remote.gameVersions.Length; i++)
             {
                 GameVersion gv = remote.gameVersions[i];
                 this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); }));
-
+                
+                allVersionsString = string.Concat(allVersionsString, (i > 0 ? ", " : "") + gv.value);
                 if (gv.value.Equals(installedVersion)) installedVersionIndex = i;
             }
+            
+            // Check if a new version has been added to BeatMods
+            if (Properties.Settings.Default.VersionsList != allVersionsString)
+            {
+                string infoMessage =
+                    "A new version of Beat Saber has been added to Beat Mods!\n" +
+                    latestVersion + "\n\n" +
+                    "This version has been selected automatically.\n" +
+                    "You can change it in the settings tab!";
+                    
+                MessageBox.Show(infoMessage, "Beat Saber v" + latestVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Properties.Settings.Default.VersionsList = allVersionsString;
+                Properties.Settings.Default.Save();
+            }
+
 
             // Show error message if installed version isn't found
             if (installedVersionIndex == -1 && installedVersion != null)
             {
-                string allVersionsString = "";
-                foreach (var versionString in remote.gameVersions)
-                {
-                    allVersionsString = allVersionsString + versionString.value;
-                }
                 string versionErrorMessage =
-                    "You have Beat Saber version " + installedVersion + " installed,\n" +
+                    "You appear to have Beat Saber version " + installedVersion + " installed,\n" +
                     "but it is not supported by Beat Mods!\n\n" +
                     "Beat Mods only supports the following versions:\n" +
                     allVersionsString +
@@ -156,7 +169,7 @@ namespace BeatSaberModManager
 
             // Set the comboBox to the installed version
             this.Invoke((MethodInvoker)(() => {
-                comboBox_gameVersions.SelectedIndex = (installedVersionIndex < 0 ? 0 : installedVersionIndex);
+                comboBox_gameVersions.SelectedIndex = 0;
             }));
 
             UpdateStatus("Loading releases...");

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -146,7 +146,7 @@ namespace BeatSaberModManager
             // God knows why
             // listViewMods.Items.Clear();
             UpdateStatus("Loading releases...");
-            //comboBox_gameVersions.Enabled = false;
+            comboBox_gameVersions.Enabled = false;
             if (!first)
             {
                 ComboBox comboBox = (ComboBox)sender;
@@ -169,7 +169,7 @@ namespace BeatSaberModManager
 
         private void ShowReleases()
         {
-            //comboBox_gameVersions.Enabled = true;
+            comboBox_gameVersions.Enabled = true;
             Dictionary<string, int> groups = new Dictionary<string, int>();
 
             listViewMods.Groups.Clear();

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -138,7 +138,7 @@ namespace BeatSaberModManager
                 allVersionsString = string.Concat(allVersionsString, (i > 0 ? ", " : "") + gv.value);
                 if (gv.value.Equals(installedVersion)) installedVersionIndex = i;
             }
-            
+
             // Check if a new version has been added to BeatMods
             if (Properties.Settings.Default.VersionsList != allVersionsString)
             {
@@ -147,8 +147,13 @@ namespace BeatSaberModManager
                     latestVersion + "\n\n" +
                     "This version has been selected automatically.\n" +
                     "You can change it in the settings tab!";
-                    
-                MessageBox.Show(infoMessage, "Beat Saber v" + latestVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+
+                // If this is a fresh install, don't show version message
+                if (Properties.Settings.Default.VersionsList != "")
+                {
+                    MessageBox.Show(infoMessage, "Beat Saber v" + latestVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+
                 Properties.Settings.Default.VersionsList = allVersionsString;
                 Properties.Settings.Default.Save();
             }

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -131,9 +131,7 @@ namespace BeatSaberModManager
                 this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); })); 
             }
             this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
-            
-            //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add("0.13.2"); }));
-            //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
+
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
             installer = new InstallerLogic(remote.releases, path.installPath);

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -123,7 +123,6 @@ namespace BeatSaberModManager
 
         private void RemoteLoad()
         {
-            /*
             UpdateStatus("Loading game versions...");
             remote.GetGameVersions();
             for (int i = 0; i < remote.gameVersions.Length; i++)
@@ -132,7 +131,7 @@ namespace BeatSaberModManager
                 this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); })); 
             }
             this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
-            */
+            
             //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add("0.13.2"); }));
             //this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
             UpdateStatus("Loading releases...");

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -235,6 +235,14 @@ namespace BeatSaberModManager
             listViewMods.Groups.Clear();
             int other = listViewMods.Groups.Add(new ListViewGroup("Other", HorizontalAlignment.Left));
             groups.Add("Other", other);
+            
+            if (remote.releases.Count <= 0)
+            {
+                string infoMessage =
+                    "There are no mods available for this game version!\n\n" +
+                    "Make sure you have the right game version selected!";
+                MessageBox.Show(infoMessage, "No mods found", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+            }
 
             foreach (ReleaseInfo release in remote.releases)
             {
@@ -268,7 +276,6 @@ namespace BeatSaberModManager
                     }
                     listViewMods.Items.Add(item);
                     release.itemHandle = item;
-
                 }
             }
 

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -13,7 +13,6 @@ using SemVer;
 using Version = SemVer.Version;
 using MaterialSkin.Controls;
 using MaterialSkin;
-using System.Text.RegularExpressions;
 
 namespace BeatSaberModManager
 {
@@ -126,24 +125,12 @@ namespace BeatSaberModManager
         {
             UpdateStatus("Loading game versions...");
             remote.GetGameVersions();
-
-            string savedGameVersion = Properties.Settings.Default.GameVersion;
-
-            // Strip whitespace in case some edits the file manually
-            savedGameVersion = Regex.Replace(savedGameVersion, @"\s+", "");
-
-            int savedSelectedIndex = 0;
             for (int i = 0; i < remote.gameVersions.Length; i++)
             {
                 GameVersion gv = remote.gameVersions[i];
                 this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); })); 
-
-                if (gv.value.Equals(savedGameVersion))
-                {
-                    savedSelectedIndex = i;
-                }
             }
-            this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = savedSelectedIndex; }));
+            this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
 
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
@@ -164,10 +151,6 @@ namespace BeatSaberModManager
             {
                 ComboBox comboBox = (ComboBox)sender;
                 GameVersion gameVersion = remote.gameVersions[comboBox.SelectedIndex];
-                
-                // Save to settings
-                Properties.Settings.Default.GameVersion = gameVersion.value;
-                Properties.Settings.Default.Save();
 
                 remote.selectedGameVersion = gameVersion;
                 new Thread(() => { LoadFromComboBox(); }).Start();

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -125,18 +125,37 @@ namespace BeatSaberModManager
         {
             UpdateStatus("Loading game versions...");
             remote.GetGameVersions();
+
+            string installedVersion = GetInstalledGameVersion();
+            int installedVersionIndex = 0;
             for (int i = 0; i < remote.gameVersions.Length; i++)
             {
                 GameVersion gv = remote.gameVersions[i];
-                this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); })); 
+                this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.Items.Add(gv.value); }));
+
+                if (gv.value.Equals(installedVersion)) installedVersionIndex = i;
             }
-            this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = 0; }));
+            this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = installedVersionIndex; }));
 
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
             installer = new InstallerLogic(remote.releases, path.installPath);
             installer.StatusUpdate += Installer_StatusUpdate;
             this.Invoke((MethodInvoker)(() => { ShowReleases(); }));
+        }
+
+        private string GetInstalledGameVersion()
+        {
+            string gameVersionFilePath = Path.Combine(path.installPath, "BeatSaberVersion.txt");
+            try
+            {
+                string[] lines = File.ReadAllLines(gameVersionFilePath);
+                return lines.First<string>();
+            } catch (Exception e)
+            {
+                Debug.WriteLine(e.Message);
+                return null;
+            }
         }
 
         bool first = true;

--- a/BeatSaberModManager/Forms/FormMain.cs
+++ b/BeatSaberModManager/Forms/FormMain.cs
@@ -127,7 +127,7 @@ namespace BeatSaberModManager
             remote.GetGameVersions();
 
             string installedVersion = GetInstalledGameVersion();
-            int installedVersionIndex = 0;
+            int installedVersionIndex = -1;
             for (int i = 0; i < remote.gameVersions.Length; i++)
             {
                 GameVersion gv = remote.gameVersions[i];
@@ -135,7 +135,27 @@ namespace BeatSaberModManager
 
                 if (gv.value.Equals(installedVersion)) installedVersionIndex = i;
             }
-            this.Invoke((MethodInvoker)(() => { comboBox_gameVersions.SelectedIndex = installedVersionIndex; }));
+
+            // Show error message if installed version isn't found
+            if (installedVersionIndex == -1 && installedVersion != null)
+            {
+                string allVersionsString = "";
+                foreach (var versionString in remote.gameVersions)
+                {
+                    allVersionsString = allVersionsString + versionString.value;
+                }
+                string versionErrorMessage =
+                    "You have Beat Saber version " + installedVersion + " installed,\n" +
+                    "but it is not supported by Beat Mods!\n\n" +
+                    "Beat Mods only supports the following versions:\n" +
+                    allVersionsString;
+                MessageBox.Show(versionErrorMessage, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
+            // Set the comboBox to the installed version
+            this.Invoke((MethodInvoker)(() => {
+                comboBox_gameVersions.SelectedIndex = (installedVersionIndex < 0 ? 0 : installedVersionIndex);
+            }));
 
             UpdateStatus("Loading releases...");
             remote.PopulateReleases();
@@ -154,6 +174,7 @@ namespace BeatSaberModManager
             } catch (Exception e)
             {
                 Debug.WriteLine(e.Message);
+                MessageBox.Show("Could not get installed game version!\n\nChange version in OPTIONS tab!\n\nERROR:\n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return null;
             }
         }

--- a/BeatSaberModManager/Forms/FormMain.resx
+++ b/BeatSaberModManager/Forms/FormMain.resx
@@ -299,9 +299,6 @@
   <metadata name="textBoxPluginsPath.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="textBoxPluginsPath.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAYAAAAAAAEAIADCigAAZgAAAICAAAABACAAKAgBACiLAABAQAAAAQAgAChCAABQkwEAMDAAAAEA

--- a/BeatSaberModManager/Properties/Settings.Designer.cs
+++ b/BeatSaberModManager/Properties/Settings.Designer.cs
@@ -94,5 +94,17 @@ namespace BeatSaberModManager.Properties {
                 this["Platform"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string VersionsList {
+            get {
+                return ((string)(this["VersionsList"]));
+            }
+            set {
+                this["VersionsList"] = value;
+            }
+        }
     }
 }

--- a/BeatSaberModManager/Properties/Settings.Designer.cs
+++ b/BeatSaberModManager/Properties/Settings.Designer.cs
@@ -94,17 +94,5 @@ namespace BeatSaberModManager.Properties {
                 this["Platform"] = value;
             }
         }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public string GameVersion {
-            get {
-                return ((string)(this["GameVersion"]));
-            }
-            set {
-                this["GameVersion"] = value;
-            }
-        }
     }
 }

--- a/BeatSaberModManager/Properties/Settings.Designer.cs
+++ b/BeatSaberModManager/Properties/Settings.Designer.cs
@@ -94,5 +94,17 @@ namespace BeatSaberModManager.Properties {
                 this["Platform"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public string GameVersion {
+            get {
+                return ((string)(this["GameVersion"]));
+            }
+            set {
+                this["GameVersion"] = value;
+            }
+        }
     }
 }

--- a/BeatSaberModManager/Properties/Settings.settings
+++ b/BeatSaberModManager/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="Platform" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="VersionsList" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/BeatSaberModManager/Properties/Settings.settings
+++ b/BeatSaberModManager/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="Platform" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="GameVersion" Type="System.String" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/BeatSaberModManager/Properties/Settings.settings
+++ b/BeatSaberModManager/Properties/Settings.settings
@@ -20,8 +20,5 @@
     <Setting Name="Platform" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="GameVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)">0</Value>
-    </Setting>
   </Settings>
 </SettingsFile>

--- a/BeatSaberModManager/app.config
+++ b/BeatSaberModManager/app.config
@@ -25,6 +25,9 @@
             <setting name="Platform" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="GameVersion" serializeAs="String">
+                <value>0</value>
+            </setting>
         </BeatSaberModManager.Properties.Settings>
     </userSettings>
 </configuration>

--- a/BeatSaberModManager/app.config
+++ b/BeatSaberModManager/app.config
@@ -25,9 +25,6 @@
             <setting name="Platform" serializeAs="String">
                 <value>0</value>
             </setting>
-            <setting name="GameVersion" serializeAs="String">
-                <value>0</value>
-            </setting>
         </BeatSaberModManager.Properties.Settings>
     </userSettings>
 </configuration>

--- a/BeatSaberModManager/app.config
+++ b/BeatSaberModManager/app.config
@@ -25,6 +25,9 @@
             <setting name="Platform" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="VersionsList" serializeAs="String">
+                <value />
+            </setting>
         </BeatSaberModManager.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27714637/57987513-360b2200-7a37-11e9-9fee-59f22554f8b9.png)


Adds back in game version support, now that Beat Mods supports it as well.
- Adds game version combo box in settings
- Reloads mods list when setting is changed, and ignores mods that don't match the setting
- Saves selected game version